### PR TITLE
Add automatic weekly check-in greet

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -146,7 +146,8 @@
       "Bash(npx skills *)",
       "Bash(npx create-video@latest --yes --blank --no-tailwind demo-video)",
       "Bash(npx remotion *)",
-      "Bash(node --experimental-strip-types scripts/generate-captions.mts)"
+      "Bash(node --experimental-strip-types scripts/generate-captions.mts)",
+      "Bash(grep -v \"^$\")"
     ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,8 +21,8 @@ over meerdere weken, en escaleert naar een zorgverlener wanneer dat nodig is.
 | MCP Server | fastmcp (Python, apart proces) | 8001 |
 | Relationele DB | PostgreSQL 16 | 5432 |
 | Vector DB | ChromaDB (RAG geheugen) | 8002 |
-| LLM | Ollama (qwen2.5:3b) of cloud: Groq / Anthropic / OpenRouter | 11434 / cloud |
-| Embeddings | bge-m3 via Ollama | 11434 |
+| LLM | Ollama (qwen2.5:3b) of cloud: Groq / Anthropic / OpenRouter / Portkey | 11434 / cloud |
+| Embeddings | bge-m3 via Ollama of text-embedding-3-large via Portkey | 11434 / cloud |
 | TTS (snel) | Piper TTS nl_NL-ronnie via HTTP-bridge | 5005 / 10200 |
 | TTS (kwaliteit) | XTTS v2 (Coqui) — GPU, stemkloning | 5006 |
 | STT | Web Speech API (browser, cloud) | — |
@@ -31,7 +31,7 @@ over meerdere weken, en escaleert naar een zorgverlener wanneer dat nodig is.
 | Omgeving | Docker Compose (alle lokale services) | — |
 
 LLM-aanroepen in `backend/services/llm.py` zijn provider-agnostisch via een abstracte klasse.
-Wisselen van provider = alleen `.env` aanpassen (`LLM_PROVIDER` + bijbehorende API key).
+Wisselen van provider kan via de **Settings-pagina** (opgeslagen in de `settings` DB-tabel, geen restart nodig) of via `.env` als fallback.
 
 ---
 
@@ -159,21 +159,40 @@ Geen bewijs in de decision log zetten.
 
 ```
 anna_remembers/
-├── frontend/                # Next.js 15
-├── backend/                 # FastAPI
+├── frontend/                # Next.js 15 (poort 3001)
+│   └── Anna-remembers/
+│       ├── app/             # App Router pages + layouts
+│       ├── components/      # chat/, patients/, trends/, escalations/, settings/
+│       ├── lib/             # api.ts, mock-data.ts, utils.ts
+│       └── types/           # TypeScript interfaces
+├── backend/                 # FastAPI (poort 8000)
 │   ├── routers/
-│   ├── models/
-│   ├── schemas/
+│   │   ├── chat/            # Chat package
+│   │   │   ├── _routes.py       # chat endpoint + greet endpoint
+│   │   │   ├── _prompts.py      # system, greet, summary prompt builders
+│   │   │   ├── _summary.py      # medische samenvatting BackgroundTask
+│   │   │   ├── _escalation.py   # Layer 0 keywords + Layer 1 classifier
+│   │   │   └── _animation.py    # avatar animatie-tag resolutie
+│   │   ├── patients.py
+│   │   ├── escalations.py
+│   │   ├── tts.py           # TTS routing (Piper / XTTS)
+│   │   ├── symptom_trends.py
+│   │   └── settings.py
+│   ├── models/              # SQLAlchemy ORM models
+│   ├── schemas/             # Pydantic request/response schemas
 │   ├── services/
-│   │   ├── llm.py           # provider-agnostisch houden
-│   │   ├── rag.py
-│   │   └── mcp_client.py
-│   └── main.py
+│   │   ├── llm.py           # provider-agnostisch: Ollama, Groq, Anthropic, OpenRouter, Portkey
+│   │   ├── mcp_client.py
+│   │   ├── tts.py
+│   │   ├── database.py
+│   │   └── symptom_extraction.py  # LLM-extractie bij sessie-einde
+│   ├── seed.py              # Demo data seeder
+│   └── alembic/             # Database migraties
 ├── mcp-server/              # fastmcp, draait apart op poort 8001
 │   └── tools/
 │       ├── memory.py        # store_memory, recall_context (RAG hier)
-│       ├── trends.py        # get_symptom_trends
-│       └── escalation.py   # escalate_to_human
+│       ├── trends.py        # get_symptom_trends (PostgreSQL)
+│       └── escalation.py    # escalate_to_human (Twilio SMS)
 ├── portfolio/
 │   ├── STAPPEN.md           # doorlopend logboek
 │   ├── decision-logs/
@@ -258,7 +277,7 @@ Deze keuzes zijn al gemaakt en gedocumenteerd. Heropener ze niet tenzij ik dat v
 
 ---
 
-## Huidige bouwstaat (bijgewerkt 2026-05-23)
+## Huidige bouwstaat (bijgewerkt 2026-06-18)
 
 ### Klaar (issue gesloten)
 - **Issue #1** — Docker Compose setup: postgres, chromadb, ollama (GPU), backend, mcp-server
@@ -267,7 +286,8 @@ Deze keuzes zijn al gemaakt en gedocumenteerd. Heropener ze niet tenzij ik dat v
 - **Issue #6** (CI) — GitHub Actions CI workflow (build-check op push + PR)
 - **Issue #7** (CD) — GitHub Actions CD workflow (push naar Docker Hub op main)
 - **Issue #9** — CI/CD pipeline gedocumenteerd als GitHub issue
-- **Issue #14** — `escalate_to_human` stub geïmplementeerd + geregistreerd als MCP-tool
+- **Issue #13** — `get_symptom_trends` (PostgreSQL week-aggregatie) — gebouwd in `backend/routers/symptom_trends.py`
+- **Issue #14** — `escalate_to_human` + Twilio SMS
 - **Issue #19** — Chat-scherm gekoppeld aan FastAPI (echte API, sessierail, history)
 - **Issue #28** — Periodieke medische samenvatting: `patients.medical_summary` elke N berichten bijgewerkt via BackgroundTask
 - **Issue #29** — Medische samenvatting geïnjecteerd in system prompt als apart blok boven RAG-dossier
@@ -275,25 +295,29 @@ Deze keuzes zijn al gemaakt en gedocumenteerd. Heropener ze niet tenzij ik dat v
 - **Issue #44** — TTS integratie: Piper + XTTS via backend, audio playback in chat
 - **Issue #45** — STT + avatar: Web Speech API microfooninvoer, 3D avatar (Three.js + GLB), lip sync met ARKit visemes
 - **TTS provider toggle** — settings page Select (Piper/XTTS), DB-driven routing via `tts_provider` setting, migration 0005
+- **LLM provider/model toggle** — settings page: provider + model instelbaar via DB, geen `.env` restart nodig
+- **Symptoomextractie bij sessie-einde** — `POST /sessions/close` triggert LLM-extractie over volledig transcript → `symptom_observations` tabel
+- **Auto wekelijkse check-in** — `POST /chat/{patient_id}/greet`: Anna stuurt het openingsbericht, haalt RAG-context op en stelt een gepersonaliseerde indirecte vraag
 
-### MCP-server — deels klaar
+### MCP-server — volledig klaar
 - ✅ `mcp-server/services/embedding.py` — `EmbeddingProvider` ABC + `OllamaEmbeddingProvider` (bge-m3)
 - ✅ `mcp-server/tools/memory.py` — `store_memory` + `recall_context` (ChromaDB)
-- ✅ `mcp-server/tools/escalation.py` — `escalate_to_human` stub
+- ✅ `mcp-server/tools/trends.py` — `get_symptom_trends` (PostgreSQL aggregatie)
+- ✅ `mcp-server/tools/escalation.py` — `escalate_to_human` (Twilio SMS)
 - ✅ `mcp-server/main.py` — alle tools geregistreerd
-- ❌ `tools/trends.py` — `get_symptom_trends` nog niet gebouwd
 
-### Chat-pipeline + voice mode (actief, feature/tts-stt-avatar branch)
-- `backend/routers/chat.py` — volledig bedraad: RAG, Postgres history, Langfuse tracing, medische samenvatting
+### Chat-pipeline (main branch)
+- `backend/routers/chat/` — package met `_routes.py`, `_prompts.py`, `_summary.py`, `_escalation.py`, `_animation.py`
+- `backend/routers/chat/_routes.py` — chat endpoint + greet endpoint (auto check-in)
+- `backend/routers/chat/_prompts.py` — `build_system_prompt()`, `build_greet_prompt()`, `build_summary_prompt()`
 - `backend/routers/tts.py` — TTS provider routing via `tts_provider` DB setting
 - `backend/services/tts.py` — Piper (`PIPER_URL`) + XTTS (`XTTS_URL`) URL-mapping per provider
-- `backend/services/llm.py` — provider-agnostisch: Ollama, Groq, Anthropic, OpenRouter
+- `backend/services/llm.py` — provider-agnostisch: Ollama, Groq, Anthropic, OpenRouter, Portkey
+- `backend/services/symptom_extraction.py` — LLM-extractie van symptoomscores bij sessie-einde
 - `frontend/.../components/chat/avatar.tsx` — Three.js GLB avatar, 72 morph targets, Web Audio API FFT, ARKit visemes
-- `frontend/.../components/settings/settings-screen.tsx` — TTS provider Select + Twilio toggle
+- `frontend/.../components/settings/settings-screen.tsx` — TTS provider Select, LLM provider/model, Twilio toggle
 
 ### Open
-- **Issue #13** — `get_symptom_trends` (PostgreSQL week-aggregatie) — nog niet gebouwd
-- **Issue #4** — Frontend dashboard volledig wiren (trends + escalaties live)
 - **Issue #47** — Offline STT (Whisper) — lage prioriteit, known limitation
 - **Issue #48** — Voice sample upload via settings — medium prioriteit
 - Gesimuleerde patiënten (10 sessies elk) draaien

--- a/README.md
+++ b/README.md
@@ -9,15 +9,24 @@ AI health assistant for heart failure patients. Conducts weekly check-ins, remem
 ## Architecture
 
 ```
-Next.js 15 (UI only, port 3000)
+Next.js 15 (UI only, port 3001)
     ↓ HTTP (REST)
 FastAPI (Python, port 8000) — orchestrates all AI logic
     ↓ MCP protocol (port 8001)
 MCP Server (fastmcp) — memory, trends, escalation tools
     ├── ChromaDB (port 8002) — vector store for RAG memory
     └── PostgreSQL 16 (port 5432) — structured patient data
-         ↑
+
+LLM routing (provider-agnostic):
     Ollama (port 11434) — local LLM + embeddings (RTX 4050)
+    Portkey gateway — routes to Azure OpenAI / OpenAI / other cloud models
+    Groq / Anthropic / OpenRouter — direct cloud providers
+
+TTS pipeline:
+    Piper TTS (port 5005 / 10200) — fast offline Dutch voice
+    XTTS v2 / Coqui (port 5006) — GPU quality voice cloning
+
+SMS escalation: Twilio
 ```
 
 **Rules:**
@@ -25,7 +34,7 @@ MCP Server (fastmcp) — memory, trends, escalation tools
 - FastAPI is the only MCP client — Next.js never talks to the MCP server
 - RAG lives in the MCP server (`tools/memory.py`), not in FastAPI
 - Every stored memory has a `source` tag: `patient_stated` or `ai_inferred`
-- Escalation detection is layered: Layer 0 (deterministic keywords, synchronous) + Layer 1 (local Ollama classifier, `BackgroundTask`)
+- Escalation detection is layered: Layer 0 (deterministic keywords, synchronous) + Layer 1 (configurable classifier, `BackgroundTask`)
 
 ---
 
@@ -33,13 +42,19 @@ MCP Server (fastmcp) — memory, trends, escalation tools
 
 | Layer | Technology | Port |
 |---|---|---|
-| Frontend | Next.js 15 (App Router) + shadcn/ui | 3000 |
+| Frontend | Next.js 15 (App Router) + shadcn/ui | 3001 |
 | Backend | FastAPI (Python) | 8000 |
 | MCP Server | fastmcp (separate process) | 8001 |
 | Vector DB | ChromaDB | 8002 |
 | Relational DB | PostgreSQL 16 | 5432 |
-| LLM + Embeddings | Ollama (gemma4:e2b + bge-m3) or cloud provider (Groq / Anthropic / OpenRouter) | 11434 / cloud |
-| Observability | Langfuse (tracing per LLM generation + RAG span) | cloud |
+| LLM | Ollama (qwen2.5:3b) or cloud via Portkey / Groq / Anthropic / OpenRouter | 11434 / cloud |
+| Embeddings | bge-m3 via Ollama or text-embedding-3-large via Portkey | 11434 / cloud |
+| TTS (fast) | Piper TTS nl_NL-ronnie — offline Dutch voice | 5005 / 10200 |
+| TTS (quality) | XTTS v2 (Coqui) — GPU voice cloning | 5006 |
+| STT | Web Speech API (browser-native, cloud) | — |
+| Avatar | Three.js GLB + ARKit visemes + Web Audio API lip sync | — |
+| Observability | Langfuse (LLM generation + RAG span tracing) | 3000 |
+| Notifications | Twilio SMS (escalation alerts) | cloud |
 | Infrastructure | Docker Compose | — |
 
 ---
@@ -53,39 +68,58 @@ MCP Server (fastmcp) — memory, trends, escalation tools
 
 ### Environment variables
 
-Create `.env` in the project root (use `.env.example` as starting point):
+Create `.env` in the project root:
 
 ```env
 POSTGRES_DB=anna_remembers
 POSTGRES_USER=anna
 POSTGRES_PASSWORD=secret
 
-# LLM provider: ollama | groq | anthropic | openrouter
-LLM_PROVIDER=groq
-GROQ_API_KEY=your_key_here
-GROQ_MODEL=llama-3.3-70b-versatile
+# LLM provider: ollama | groq | anthropic | openrouter | portkey
+LLM_PROVIDER=ollama
+OLLAMA_MODEL=qwen2.5:3b
+OLLAMA_BASE_URL=http://ollama:11434
 
-# For local Ollama (GPU recommended — gemma4:e2b fits in 6 GiB VRAM)
-OLLAMA_MODEL=gemma4:e2b
-EMBEDDING_MODEL=bge-m3
+# Groq (fast free tier — recommended for demo)
+GROQ_API_KEY=
+GROQ_MODEL=llama-3.1-8b-instant
 
-# Layer 1 escalation classifier (small local Ollama model)
-# qwen2.5:3b is the validated choice — 0.5b proved too small for Dutch reasoning.
-ESCALATION_MODEL=qwen2.5:3b
-ESCALATION_COOLDOWN_MINUTES=0   # set >0 to suppress duplicate Layer 1 escalations per patient
-
-# Optional: Anthropic or OpenRouter
+# Anthropic
 ANTHROPIC_API_KEY=
 ANTHROPIC_MODEL=claude-haiku-4-5-20251001
+
+# OpenRouter
 OPENROUTER_API_KEY=
 OPENROUTER_MODEL=
+
+# Portkey gateway (routes to Azure OpenAI or other configured targets)
+PORTKEY_API_KEY=
+PORTKEY_MODEL=@azure-openai/gpt-5.4
+PORTKEY_CONFIG=
+
+# Embeddings provider: ollama | portkey
+EMBEDDING_PROVIDER=ollama
+OPENAI_EMBEDDING_MODEL=@azure-openai/text-embedding-3-large
+PORTKEY_EMBEDDING_CONFIG=
+
+# Layer 1 escalation classifier
+# Can use any supported provider (portkey, ollama, openai_compat)
+ESCALATION_PROVIDER=ollama
+ESCALATION_MODEL=qwen2.5:3b
+ESCALATION_COOLDOWN_MINUTES=0
+
+# Twilio SMS escalation alerts
+TWILIO_ACCOUNT_SID=
+TWILIO_AUTH_TOKEN=
+TWILIO_FROM=
+NOTIFICATION_PHONE=
 
 # Observability (optional)
 LANGFUSE_PUBLIC_KEY=
 LANGFUSE_SECRET_KEY=
-LANGFUSE_HOST=https://cloud.langfuse.com
+LANGFUSE_BASE_URL=https://cloud.langfuse.com
 
-# Summary generation interval (messages per patient before regenerating)
+# Medical summary regeneration interval (messages per patient)
 SUMMARY_INTERVAL=3
 ```
 
@@ -98,17 +132,16 @@ docker compose up --build
 On first run, `ollama-init` pulls the `bge-m3` embedding model automatically. If using Ollama as the LLM provider, pull the chat model and the Layer 1 escalation classifier once manually:
 
 ```bash
-docker exec -it anna_remembers-ollama-1 ollama pull gemma4:e2b
 docker exec -it anna_remembers-ollama-1 ollama pull qwen2.5:3b
 ```
 
-For cloud providers (Groq, Anthropic, OpenRouter), set `LLM_PROVIDER` and the matching API key in `.env` — no local chat model needed. The Layer 1 escalation classifier always runs locally via Ollama (`ESCALATION_MODEL`).
+For cloud providers (Groq, Anthropic, OpenRouter, Portkey), set `LLM_PROVIDER` and the matching API key in `.env` — no local chat model needed. If using Ollama for the Layer 1 escalation classifier, the model still needs to be pulled.
 
 ### Services
 
 | Service | URL |
 |---|---|
-| Frontend dashboard | http://localhost:3000 |
+| Frontend dashboard | http://localhost:3001 |
 | Backend API | http://localhost:8000 |
 | API docs (Swagger) | http://localhost:8000/docs |
 | MCP Server | http://localhost:8001 |
@@ -152,7 +185,7 @@ anna_remembers/
 │       ├── components/     # Feature-based components
 │       │   ├── dashboard/  # Sidebar, shell, status badge
 │       │   ├── patients/   # Patient management screen
-│       │   ├── chat/       # Chat screen
+│       │   ├── chat/       # Chat screen (text + voice mode + avatar)
 │       │   ├── trends/     # Symptom trends screen
 │       │   └── escalations/# Escalation management screen
 │       ├── lib/            # api.ts, mock-data.ts, utils.ts
@@ -162,14 +195,17 @@ anna_remembers/
 │   ├── routers/
 │   │   ├── patients.py
 │   │   ├── escalations.py
-│   │   └── chat/           # Chat package (refactored from single file)
-│   │       ├── _routes.py      # FastAPI handlers
-│   │       ├── _prompts.py     # System + summary prompt builders
+│   │   ├── tts.py          # TTS provider routing (Piper / XTTS)
+│   │   ├── symptom_trends.py
+│   │   └── chat/           # Chat package
+│   │       ├── _routes.py      # FastAPI handlers (chat + greet endpoint)
+│   │       ├── _prompts.py     # System, greet, and summary prompt builders
 │   │       ├── _summary.py     # Periodic medical_summary BackgroundTask
-│   │       └── _escalation.py  # Layer 0 keywords + Layer 1 Ollama classifier
+│   │       ├── _escalation.py  # Layer 0 keywords + Layer 1 classifier
+│   │       └── _animation.py   # Avatar animation tag resolution
 │   ├── models/             # SQLAlchemy ORM models
 │   ├── schemas/            # Pydantic request/response schemas
-│   ├── services/           # llm.py, database.py, mcp_client.py
+│   ├── services/           # llm.py, database.py, mcp_client.py, tts.py
 │   ├── seed.py             # Demo data seeder (Postgres + ChromaDB)
 │   └── alembic/            # Database migrations
 │
@@ -196,7 +232,7 @@ anna_remembers/
 | `store_memory(content, source, patient_id, session_id)` | Stores a memory in ChromaDB. `source` is `patient_stated` or `ai_inferred` |
 | `recall_context(query, patient_id, limit)` | Semantic RAG search over patient history |
 | `get_symptom_trends(patient_id, weeks)` | Retrieves aggregated symptom data from PostgreSQL |
-| `escalate_to_human(patient_id, reason, urgency)` | Sends notification via email or Slack based on urgency |
+| `escalate_to_human(patient_id, reason, urgency)` | Sends SMS via Twilio based on urgency |
 
 ---
 
@@ -204,10 +240,26 @@ anna_remembers/
 
 | Screen | Route | Status |
 |---|---|---|
-| Patient management | `/patients` | Live (FastAPI) |
-| Chat with Anna | `/chat` | Live (FastAPI + RAG + medical summary) |
-| Symptom trends | `/trends` | Mock (awaiting `get_symptom_trends` MCP tool) |
-| Escalation management | `/escalations` | Live (Layer 0 + Layer 1 detection)
+| Patient management | `/patients` | Live |
+| Chat with Anna | `/chat` | Live — RAG, medical summary, TTS, STT, avatar, auto check-in |
+| Symptom trends | `/trends` | Live — weekly aggregates from PostgreSQL |
+| Escalation management | `/escalations` | Live — Layer 0 + Layer 1 detection, Twilio SMS |
+
+---
+
+## Chat features
+
+**Auto weekly check-in:** When a new session opens, Anna sends the first message. She queries RAG for earlier statements from this patient and generates a personalised, indirect opening question (e.g. *"Last time you mentioned some shortness of breath — how has that been this week?"*). The patient does not need to know how to start.
+
+**Voice mode:** Toggle between text and voice in the chat header. The browser's Web Speech API handles speech-to-text; the backend synthesises Anna's reply via Piper (fast, offline) or XTTS v2 (GPU, voice cloning), selectable per patient in Settings.
+
+**3D avatar:** A Three.js GLB model with 72 ARKit morph targets lip-syncs to Anna's audio using Web Audio API FFT frequency analysis. Animation state is driven by tags (`[ANIM: x]`) embedded in the LLM response and stripped before display.
+
+**RAG memory:** Patient statements are stored in ChromaDB with `source=patient_stated`. Anna's inferred summaries use `source=ai_inferred`. Only `patient_stated` memories are injected into the system prompt — Anna never fabricates facts.
+
+**Medical summary:** Every `SUMMARY_INTERVAL` messages, a compact JSON dossier (`sym/med/wgt/bhv/ovr`) is regenerated in the background and shown in the Dossier panel.
+
+**Symptom extraction:** When a session is closed, the full transcript is passed to an LLM that extracts structured symptom scores (dyspnea, edema, fatigue, medication adherence, weight) and stores them in `symptom_observations` for the trends chart.
 
 ---
 
@@ -218,11 +270,11 @@ A patient message is checked twice for emergencies, in two layers:
 | Layer | When | How | Latency |
 |---|---|---|---|
 | **Layer 0** | Synchronous, before LLM | Hardcoded Dutch keyword sets (`pijn op de borst`, `bewusteloos`, `brandwond`, …) split into `high` and `medium` | ~0 ms |
-| **Layer 1** | Async `BackgroundTask` after the response is sent | Local Ollama classifier (`qwen2.5:3b`) returns `{escalate, urgency, reason}` JSON. Per-patient semaphore + optional cooldown prevent duplicates | ~3–5 s |
+| **Layer 1** | Async `BackgroundTask` after the response is sent | Configurable classifier (Portkey / Ollama / OpenAI-compatible) returns `{escalate, urgency, reason}` JSON. Per-patient semaphore + optional cooldown prevent duplicates | ~1–5 s |
 
-Layer 0 fires before the chat response so urgent cases trigger immediately. Layer 1 catches nuanced cases that keyword matching misses (e.g. "ik werd vannacht wakker omdat ik geen lucht kreeg"). Both paths call `escalate_to_human` via MCP. Every Layer 1 call is traced in Langfuse with input, output and model metadata.
+Layer 0 fires before the chat response so urgent cases trigger immediately. Layer 1 catches nuanced cases that keyword matching misses (e.g. *"ik werd vannacht wakker omdat ik geen lucht kreeg"*). Both paths call `escalate_to_human` via MCP, which sends a Twilio SMS. Every Layer 1 call is traced in Langfuse.
 
-The classifier model is configurable via `ESCALATION_MODEL`. `qwen2.5:0.5b` was tested first and rejected — too small to reason in Dutch without hallucinating reasons. `qwen2.5:3b` is the current production choice. See `portfolio/decision-logs/DL4_escalatie_detectie.md`.
+The classifier model is configurable via `ESCALATION_MODEL` and `ESCALATION_PROVIDER`. `qwen2.5:0.5b` was tested first and rejected — too small to reason in Dutch without hallucinating reasons. See `portfolio/decision-logs/DL4_escalatie_detectie.md`.
 
 ---
 

--- a/backend/routers/chat/_prompts.py
+++ b/backend/routers/chat/_prompts.py
@@ -39,22 +39,7 @@ def build_system_prompt(patient: Patient, memories: list[dict]) -> str:
     return (
         f"Je bent Anna, een empathische AI-gezondheidsassistent voor hartfalenpatiënten. "
         f"Je spreekt met {name}.\n\n"
-        f"BELANGRIJK — Animatie-tag (eerste regel van élke response):\n"
-        f"- Begin je antwoord ALTIJD met `[ANIM: x]` op een eigen regel, waarbij x exact één is van:\n"
-        f"  • standard_waiting\n"
-        f"  • stand_look_around\n"
-        f"  • running_fast\n"
-        f"  • standard_walk_crouching\n"
-        f"  • flexing_arm\n"
-        f"  • gorilla\n"
-        f"  • laying_on_floor\n"
-        f"  • just_chilling\n"
-        f"  • angry\n"
-        f"  • Expressing_joy\n"
-        f"  • model\n"
-        f"  • model (13)\n"
-        f"- Voorbeeld: `[ANIM: angry]\\nLiesbeth, dat klinkt zorgwekkend...`\n"
-        f"- De tag wordt automatisch verwijderd voordat de patiënt het ziet.\n\n"
+        f"{_ANIM_INSTRUCTION}"
         f"Gedragsregels:\n"
         f"- Verzin nooit symptomen, medicatie of gewicht die de patiënt niet heeft gemeld.\n"
         f"- Stel maximaal één gerichte vervolgvraag per response.\n"
@@ -68,6 +53,75 @@ def build_system_prompt(patient: Patient, memories: list[dict]) -> str:
         f"- Als de patiënt een telefoonnummer deelt: noteer het kort. Gebruik het niet voor "
         f"dramatische belplannen.\n"
         f"- Reageer proportioneel op het huidige bericht, niet op het patroon van eerdere berichten.\n\n"
+        f"Patiëntgegevens:\n"
+        f"- Naam: {name}\n"
+        f"- Medicatieschema: {medication}\n"
+        f"- Notities zorgverlener: {notes}"
+        f"{summary_block}"
+        f"{memory_block}"
+    )
+
+
+_ANIM_INSTRUCTION = (
+    "BELANGRIJK — Animatie-tag (eerste regel van élke response):\n"
+    "- Begin je antwoord ALTIJD met `[ANIM: x]` op een eigen regel, waarbij x exact één is van:\n"
+    "  • standard_waiting\n"
+    "  • stand_look_around\n"
+    "  • running_fast\n"
+    "  • standard_walk_crouching\n"
+    "  • flexing_arm\n"
+    "  • gorilla\n"
+    "  • laying_on_floor\n"
+    "  • just_chilling\n"
+    "  • angry\n"
+    "  • Expressing_joy\n"
+    "  • model\n"
+    "  • model (13)\n"
+    "- De tag wordt automatisch verwijderd voordat de patiënt het ziet.\n\n"
+)
+
+
+def build_greet_prompt(patient: Patient, memories: list[dict]) -> str:
+    """Build Anna's system prompt for the weekly check-in opening message."""
+    name = patient.first_name
+    medication = json.dumps(patient.medication_schedule, ensure_ascii=False)
+    notes = patient.notes or "Geen aanvullende notities."
+
+    useful = [
+        m
+        for m in memories
+        if m.get("source") == "patient_stated" and (m.get("distance") or 0) > 0.08
+    ]
+
+    memory_block = ""
+    if useful:
+        lines = "\n".join(f"• {m['content']}" for m in useful)
+        memory_block = (
+            f"\n\nWat {name} eerder heeft verteld (gebruik dit voor een gerichte openingsvraag):\n{lines}"
+        )
+
+    summary_block = ""
+    if patient.medical_summary:
+        summary_block = f"\n\nMedische achtergrond:\n{patient.medical_summary}"
+
+    return (
+        f"Je bent Anna, een empathische AI-gezondheidsassistent voor hartfalenpatiënten. "
+        f"Je spreekt met {name}.\n\n"
+        f"{_ANIM_INSTRUCTION}"
+        f"Het is tijd voor de wekelijkse check-in met {name}. "
+        f"Stuur het openingsbericht van dit gesprek.\n\n"
+        f"Regels voor het openingsbericht:\n"
+        f"- Begroet {name} vriendelijk bij naam.\n"
+        f"- Stel precies één open, indirecte vraag over hoe het die week is gegaan — "
+        f"vraag niet rechtstreeks naar symptomen of medicatie. "
+        f"Vraag bijvoorbeeld hoe {name} zich voelt, hoe de afgelopen week was, "
+        f"of er iets opviel deze week.\n"
+        f"- Als er eerdere informatie beschikbaar is, verwijs er dan subtiel naar "
+        f"(bv. 'De vorige keer vertelde je dat je wat kortademig was — hoe gaat dat nu?').\n"
+        f"- Sluit af met een korte zin die duidelijk maakt wat {name} kan delen "
+        f"(klachten, hoe de week was, medicatie, gewicht — wat dan ook).\n"
+        f"- Houd het kort: maximaal 3 zinnen.\n"
+        f"- Toon: warm en uitnodigend.\n\n"
         f"Patiëntgegevens:\n"
         f"- Naam: {name}\n"
         f"- Medicatieschema: {medication}\n"

--- a/backend/routers/chat/_routes.py
+++ b/backend/routers/chat/_routes.py
@@ -31,7 +31,7 @@ from sqlalchemy.orm import Session
 
 from ._animation import resolve_animation
 from ._escalation import format_escalation_reason, layer0_check, layer1_classify
-from ._prompts import build_system_prompt
+from ._prompts import build_greet_prompt, build_system_prompt
 from ._summary import _SUMMARY_INTERVAL, trigger_summary_update
 from services.symptom_extraction import extract_and_store_symptoms
 
@@ -281,6 +281,79 @@ def close_session(
         "message_count": count,
         "is_open": False,
     }
+
+
+@router.post(
+    "/{patient_id}/greet",
+    response_model=MessageResponse,
+    response_model_exclude_none=True,
+    responses={
+        404: {"description": "Patiënt niet gevonden"},
+        409: {"description": "Sessie bevat al berichten"},
+    },
+)
+async def greet_patient(
+    patient_id: uuid.UUID,
+    db: Annotated[Session, Depends(get_db)],
+    mcp: Annotated[MCPClient, Depends(get_mcp_client)],
+) -> MessageResponse:
+    """Generate Anna's weekly check-in opening message for an empty session."""
+    patient = db.get(Patient, patient_id)
+    if not patient:
+        raise HTTPException(status_code=404, detail="Patiënt niet gevonden")
+
+    # Find or create open session
+    session = (
+        db.query(ChatSession)
+        .filter(ChatSession.patient_id == patient_id, ChatSession.ended_at.is_(None))
+        .first()
+    )
+    if not session:
+        session = ChatSession(patient_id=patient_id)
+        db.add(session)
+        db.commit()
+        db.refresh(session)
+
+    # Idempotent: if session already has messages, don't greet again
+    existing_count: int = (
+        db.query(func.count(Message.id))
+        .filter(Message.session_id == session.id)
+        .scalar()
+    ) or 0
+    if existing_count > 0:
+        raise HTTPException(status_code=409, detail="Sessie bevat al berichten")
+
+    # RAG: retrieve earlier context for a personalised opening question
+    rag_query = "wekelijkse check-in klachten kortademigheid gewicht oedeem hoe gaat het"
+    rag_result = await mcp.recall_context(
+        query=rag_query, patient_id=str(patient_id), limit=_RAG_LIMIT
+    )
+    memories: list[dict] = rag_result if isinstance(rag_result, list) else []
+
+    system_prompt = build_greet_prompt(patient, memories)
+
+    from models.setting import Setting as SettingModel
+    llm_provider_row = db.query(SettingModel).filter(SettingModel.key == "llm_provider").first()
+    llm_model_row = db.query(SettingModel).filter(SettingModel.key == "llm_model").first()
+    llm = get_llm_provider(
+        provider=llm_provider_row.value if llm_provider_row else None,
+        model=llm_model_row.value if llm_model_row else None,
+    )
+
+    # No user message — Anna opens the conversation
+    raw_response = await llm.chat(messages=[], system=system_prompt)
+
+    clean_response, animation = resolve_animation("", raw_response)
+
+    assistant_message = Message(
+        session_id=session.id, role="assistant", content=clean_response
+    )
+    db.add(assistant_message)
+    db.commit()
+    db.refresh(assistant_message)
+
+    base = MessageResponse.model_validate(assistant_message)
+    return base.model_copy(update={"animation": animation})
 
 
 @router.post(

--- a/frontend/Anna-remembers/components/chat/chat-screen.tsx
+++ b/frontend/Anna-remembers/components/chat/chat-screen.tsx
@@ -35,6 +35,7 @@ import {
   getChatMessages,
   sendMessage,
   closeSession,
+  greetSession,
 } from "@/lib/api"
 import type { ChatSession } from "@/lib/api"
 import type { Patient, Message, MedicalSummaryJSON } from "@/types"
@@ -90,7 +91,7 @@ export function ChatScreen() {
       .finally(() => setLoadingSessions(false))
   }, [patientId])
 
-  // Load messages when session changes
+  // Load messages when session changes; auto-greet if session is empty and open
   useEffect(() => {
     if (!activeId || !patientId) return
     if (msgMap[activeId]) return // already loaded
@@ -98,12 +99,52 @@ export function ChatScreen() {
     const patient = patients.find((p) => p.id === patientId)
     if (!patient) return
 
+    const isOpenSession = sessions.find((s) => s.id === activeId)?.isOpen ?? false
+
     setLoadingMsgs(true)
     getChatMessages(patientId, activeId, patient.first)
-      .then((msgs) => setMsgMap((prev) => ({ ...prev, [activeId]: msgs })))
-      .catch(() => toast.error("Kon gesprekshistorie niet laden"))
-      .finally(() => setLoadingMsgs(false))
-  }, [activeId, patientId, patients, msgMap])
+      .then(async (msgs) => {
+        if (msgs.length === 0 && isOpenSession) {
+          // Lege open sessie — Anna opent het gesprek
+          setLoadingMsgs(false)
+          setTyping(true)
+          try {
+            const greeting = await greetSession(patientId)
+            if (greeting) {
+              const annaMsg: Message = {
+                role: "them",
+                who: "Anna",
+                t: fmtTime(),
+                body: greeting.reply,
+                animation: greeting.animation,
+              }
+              setMsgMap((prev) => ({ ...prev, [activeId]: [annaMsg] }))
+              setSessions((prev) =>
+                prev.map((s) =>
+                  s.id === activeId ? { ...s, messageCount: 1 } : s
+                )
+              )
+            } else {
+              // 409: er zijn al berichten — opnieuw laden
+              const fresh = await getChatMessages(patientId, activeId, patient.first)
+              setMsgMap((prev) => ({ ...prev, [activeId]: fresh }))
+            }
+          } catch {
+            toast.error("Anna kon de check-in niet starten")
+            setMsgMap((prev) => ({ ...prev, [activeId]: [] }))
+          } finally {
+            setTyping(false)
+          }
+        } else {
+          setMsgMap((prev) => ({ ...prev, [activeId]: msgs }))
+          setLoadingMsgs(false)
+        }
+      })
+      .catch(() => {
+        toast.error("Kon gesprekshistorie niet laden")
+        setLoadingMsgs(false)
+      })
+  }, [activeId, patientId, patients, msgMap, sessions])
 
   const patient = patients.find((p) => p.id === patientId)
   const messages = activeId ? (msgMap[activeId] ?? []) : []
@@ -303,16 +344,44 @@ export function ChatScreen() {
                 if (!patientId) return
                 try {
                   await closeSession(patientId)
-                  // Reload sessions — closed session is in the list, activeId becomes null
-                  const ss = await getChatSessions(patientId)
-                  setSessions(ss)
-                  setActiveId(null)
-                  setMsgMap({})
                 } catch {
                   toast.error("Kon sessie niet afsluiten")
+                  return
+                }
+                // Start nieuwe sessie: Anna stuurt de check-in openingsvraag
+                setActiveId(null)
+                setMsgMap({})
+                setTyping(true)
+                try {
+                  const greeting = await greetSession(patientId)
+                  if (greeting) {
+                    const newSession = {
+                      id: greeting.sessionId,
+                      date: new Date().toISOString().slice(0, 10),
+                      messageCount: 1,
+                      isOpen: true,
+                    }
+                    const ss = await getChatSessions(patientId)
+                    setSessions(ss.some((s) => s.id === greeting.sessionId) ? ss : [newSession, ...ss])
+                    setActiveId(greeting.sessionId)
+                    const annaMsg: Message = {
+                      role: "them",
+                      who: "Anna",
+                      t: fmtTime(),
+                      body: greeting.reply,
+                      animation: greeting.animation,
+                    }
+                    setMsgMap({ [greeting.sessionId]: [annaMsg] })
+                  }
+                } catch {
+                  toast.error("Anna kon de check-in niet starten")
+                  const ss = await getChatSessions(patientId)
+                  setSessions(ss)
+                } finally {
+                  setTyping(false)
                 }
               }}
-              disabled={!sessions.some((s) => s.isOpen)}
+              disabled={!patientId}
             >
               <Plus className="size-3.5" />
             </Button>

--- a/frontend/Anna-remembers/lib/api.ts
+++ b/frontend/Anna-remembers/lib/api.ts
@@ -275,6 +275,43 @@ export async function closeSession(patientId: string): Promise<void> {
   await post(`/chat/${patientId}/sessions/close`, {})
 }
 
+const _validAnimations = [
+  "standard_waiting", "stand_look_around", "running_fast",
+  "standard_walk_crouching", "flexing_arm", "gorilla", "laying_on_floor",
+  "just_chilling", "angry", "Expressing_joy", "model", "model (13)",
+] as const
+
+function _resolveAnimation(raw: string | null | undefined): import("@/types").Animation {
+  return raw && (_validAnimations as readonly string[]).includes(raw)
+    ? (raw as import("@/types").Animation)
+    : "standard_waiting"
+}
+
+export async function greetSession(patientId: string): Promise<{
+  reply: string
+  sessionId: string
+  animation: import("@/types").Animation
+} | null> {
+  const res = await fetch(`${BASE}/chat/${patientId}/greet`, { method: "POST" })
+  if (res.status === 409) return null
+  if (!res.ok) throw new Error(`API ${res.status}`)
+  const data = (await res.json()) as MessageResponseAPI
+  return {
+    reply: data.content,
+    sessionId: data.session_id,
+    animation: _resolveAnimation(data.animation),
+  }
+}
+
+export async function getSessionMemories(
+  patientId: string,
+  sessionId: string
+): Promise<import("@/types").SessionMemory[]> {
+  return get<import("@/types").SessionMemory[]>(
+    `/patients/${patientId}/sessions/${sessionId}/memories`
+  )
+}
+
 export async function getChatSessions(
   patientId: string
 ): Promise<ChatSession[]> {

--- a/frontend/Anna-remembers/lib/api.ts
+++ b/frontend/Anna-remembers/lib/api.ts
@@ -7,7 +7,6 @@ import type {
   PatientStatus,
   Settings,
   SymptomObservationRead,
-  SessionMemory,
 } from "@/types"
 
 const BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000"
@@ -242,14 +241,10 @@ export async function getSymptomObservation(patientId: string, sessionId: string
   return get<SymptomObservationRead>(`/patients/${patientId}/symptom-observations/${sessionId}`)
 }
 
-export async function getSessionMemories(patientId: string, sessionId: string): Promise<SessionMemory[]> {
-  return get<SessionMemory[]>(`/patients/${patientId}/sessions/${sessionId}/memories`)
-}
-
 // ─── Chat ─────────────────────────────────────────────────────────
 
 interface SessionAPI {
-  id: string
+  id: string  
   started_at: string
   ended_at: string | null
   message_count: number

--- a/portfolio/STAPPEN.md
+++ b/portfolio/STAPPEN.md
@@ -2472,3 +2472,27 @@ Geïmplementeerde onderdelen:
 - Merge als vangnet bij her-extractie (zelfde session_id)
 
 **Evidence:** Nog niet — handmatig testen: sessie met 10+ berichten → sluiten → check `symptom_observations`
+
+---
+
+## Stap 110 — 2026-06-17 — Anna opent de check-in zelf
+
+**Wat:**
+- Nieuw backend endpoint `POST /chat/{patient_id}/greet` toegevoegd
+- Anna stuurt de **eerste bericht** bij elke nieuwe sessie — patiënt hoeft niet meer zelf te beginnen
+- Anna haalt via RAG eerdere uitspraken op en stelt een indirecte, gepersonaliseerde openingsvraag
+- Idempotent: geeft HTTP 409 terug als de sessie al berichten bevat
+
+**Frontend gedrag:**
+- Bij lege open sessie: chat-screen detecteert dit en roept greet aan (typing indicator zichtbaar)
+- `+` knop (nieuwe sessie): sluit huidige sessie → roept greet aan → nieuwe sessie met Anna's openingsbericht
+- `greetSession()` toegevoegd aan `lib/api.ts`
+
+**Beslissingen:**
+- RAG-query: "wekelijkse check-in klachten kortademigheid gewicht oedeem hoe gaat het" → trekt eerdere symptoomuitspraken op
+- Aparte `build_greet_prompt()` in `_prompts.py` — andere instructie dan regulier gesprek: max 3 zinnen, één indirecte vraag, verwijzing naar eerder gemelde klachten
+- 409 als sessie al berichten heeft → frontend laadt berichten opnieuw uit DB
+- `_ANIM_INSTRUCTION` geëxtraheerd als constante zodat beide prompts dezelfde animatie-instructie gebruiken
+
+**Evidence:** Niet nodig — functionele feature, geen architectuurkeuze die gedocumenteerd moet worden
+


### PR DESCRIPTION
Introduce POST /chat/{patient_id}/greet to generate Anna's opening message for empty sessions. Uses RAG to pull recent patient statements and
build_greet_prompt, and reuses the extracted _ANIM_INSTRUCTION constant. Endpoint is idempotent (returns 409 if the session already has messages).
Frontend: add greetSession API, auto-invoke on empty open sessions and when
starting a new session, and resolve animation + typing UI handling.